### PR TITLE
Pass alt tags on remote images through to markdown-it renderer

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ module.exports = function markdownItEleventyImg(md, {
     }
 
     if(Image.Util.isRemoteUrl(src)) {
+      token.attrs[token.attrIndex('alt')][1] = tokenAttributes.alt
       return renderer.renderToken(tokens, index, rendererOptions);
     }
     

--- a/test.js
+++ b/test.js
@@ -17,6 +17,7 @@ const imgWithoutTitle = '![Alt diplomees2021](./assets/images/diplomees2021.jpg)
 const imgWithEmptyTitle = '![Alt diplomees2021](./assets/images/diplomees2021.jpg "")';
 const remoteSrc = "https://apod.nasa.gov/apod/image/2208/StargateMilkyWay_Oudoux_1800.jpg"
 const remoteImage = `![](${remoteSrc})`;
+const remoteImageAlt = `![My cool space pic](${remoteSrc})`
 
 test("Empty string title is undefined", t => {
   md.use(markdownItEleventyImg, {
@@ -315,6 +316,18 @@ test.serial("Remote images falls back to default markdown-it renderer", t => {
   .render(remoteImage);
 
   t.is(result, '<p><img src="https://apod.nasa.gov/apod/image/2208/StargateMilkyWay_Oudoux_1800.jpg" alt=""></p>\n');
+});
+
+test.serial("Remote images properly pass through alt tags into customised markdown-it-renderer", t => {
+  const result = md
+  .use(markdownItEleventyImg, {
+    imgOptions: {
+      dryRun: true
+    }
+  })
+  .render(remoteImageAlt);
+
+  t.is(result, '<p><img src="https://apod.nasa.gov/apod/image/2208/StargateMilkyWay_Oudoux_1800.jpg" alt="My cool space pic"></p>\n');
 });
 
 test.serial("Remote images with `statsByDimensionsSync`", t => {


### PR DESCRIPTION
Closes: #2 

I was going to switch over to the latest version but I noticed that alt tags on my existing remote images weren't working.

Looking at the `markdown-it` source, I can see that there is [some alt tag handling](https://github.com/markdown-it/markdown-it/blob/master/lib/renderer.js#L101) that needs to be ported over given that the base image renderer is overwritten.

**Before**:
<img width="957" alt="CleanShot 2022-08-19 at 22 07 48@2x" src="https://user-images.githubusercontent.com/14816406/185599671-d9e1bc99-1e90-42f3-95f0-064236a3ddbc.png">

**After**:
<img width="1045" alt="CleanShot 2022-08-19 at 22 18 35@2x" src="https://user-images.githubusercontent.com/14816406/185599701-be4329a6-fea1-4a08-9df5-d87c684f42f2.png">

I've confirmed that alt tags now appear nicely and I've also added an extra test case to assert this 🙂 

I was originally going to add a comment about it but I figure it's such a small addition that I might as well just save you the hassle by opening a PR